### PR TITLE
1. Reorder imports to follow best practice of separating system libs

### DIFF
--- a/report.py
+++ b/report.py
@@ -1,13 +1,12 @@
 #! /usr/bin/env python
 
-import channel
-import decimal
-
 import collections
 import copy
+import decimal
 import json
 import time
 
+import channel
 import config
 import configuration
 import user
@@ -530,7 +529,7 @@ class Report(object):
         turn it into an ordered dict ordered from key with most to least.
         If given something other than a dict, this returns an empty dict
         """
-        if type(d) != dict:
+        if type(d) not in [dict, collections.OrderedDict, collections.defaultdict]:
             return {}
         dk = list(d.keys())
         first_elem = d[dk[0]]


### PR DESCRIPTION
from project libs;

2. when running orderdict, we were assuming that if the 'dict' we're
trying to order is not of type dict we should simply return an empty
dict; this ignored cases where we run it on objects that are
defaultdicts or ordereddicts; so added that to the exception list