### PR TITLE
firstpost tweaks to include how long ago you posted your first message

### DIFF
--- a/firstpost.py
+++ b/firstpost.py
@@ -1,5 +1,6 @@
 
 
+import datetime
 import json
 import sys
 import time
@@ -21,14 +22,21 @@ class FirstPost(object):
         self.channel = None
         self.fake = fake
 
-    def url(self, uid):
-        entry = self.get(uid)
-        if not entry:
-            return None
-        mid = entry['message_id']
-        cid = entry['slack_cid']
-        url = utils.make_url(cid, mid)
-        return url
+    def date(self, ts):
+        """
+        return yyyy-mm-dd for ts
+        """
+        localtime = time.localtime(ts)
+        return time.strftime("%Y-%m-%d", localtime)
+
+    def days(self, ts):
+        """
+        return date difference between today and the ts
+        """
+        then = datetime.datetime.fromtimestamp(ts)
+        now = datetime.datetime.now()
+        diff = now - then
+        return diff.days
 
     def get(self, key):
         if key in self.users:
@@ -37,6 +45,9 @@ class FirstPost(object):
         item = response.get("Item")
         if item:
             item['ts'] = int(item['ts'])
+            item['url'] = utils.make_url(item['slack_cid'], item['message_id'])
+            item['days'] = self.days(item['ts'])
+            item['date'] = self.date(item['ts'])
         self.users[key] = item
         return item
 

--- a/slack_user_report.py
+++ b/slack_user_report.py
@@ -81,9 +81,9 @@ class SlackUserReport(object):
         entry = self.fp.get(uid)
         if not entry:
             return blocks
-        url = utils.make_url(entry['slack_cid'], entry['message_id'])
-        m = "By the way, your first-ever message (to the best of our knowledge) was {}"
-        m = m.format(url)
+        m = "By the way, your first-ever message (to the best of our knowledge) was {}, "
+        m += "on {}, {} days ago"
+        m = m.format(entry['url'], entry['date'], entry['days'])
         blocks.append(self.sf.text_block(m))
         return blocks
 


### PR DESCRIPTION
refactor code in slack_user_report so we don't create the first message
URL in multiple places; in firstpost.py, remove the special-purpose
url() method and just include a url in the entry returned by get();
get() entry returned now also has a 'days' and 'date' components, which
we use in the enhanced message in the slack user report