### PR TITLE
Change days ago difference calculation to operate on dates rather than times

### DIFF
--- a/firstpost.py
+++ b/firstpost.py
@@ -33,8 +33,8 @@ class FirstPost(object):
         """
         return date difference between today and the ts
         """
-        then = datetime.datetime.fromtimestamp(ts)
-        now = datetime.datetime.now()
+        then = datetime.datetime.fromtimestamp(ts).date()
+        now = datetime.date.today()
         diff = now - then
         return diff.days
 

--- a/user_created.py
+++ b/user_created.py
@@ -31,8 +31,8 @@ class UserCreated(object):
         """
         return date difference between today and the ts
         """
-        then = datetime.datetime.fromtimestamp(ts)
-        now = datetime.datetime.now()
+        then = datetime.datetime.fromtimestamp(ts).date()
+        now = datetime.date.today()
         diff = now - then
         return diff.days
 


### PR DESCRIPTION
Instead of:

> By the way, your first-ever message (to the best of our knowledge) was […], on 2015-10-26, 1,454 days ago
> Your account was created on 2015-10-26, 1,455 days ago

This calculates the dates in a more consistent way.