### PR TITLE
We know that when dealing with channels that have had no activity,

### DIFF
--- a/user_and_channel_report
+++ b/user_and_channel_report
@@ -40,5 +40,9 @@ for user in users:
     slack_user_reporter.send_report(user, report, previous_report, send=True)
 
 for channel in channels:
-    dest = channel_dict[channel]
-    slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
+    try:
+        dest = channel_dict[channel]
+        slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
+    except:
+        print("Failed to send report to {}".format(channel))
+


### PR DESCRIPTION
we will fail to generate the report.   Rigth now, this is just a
workaround to make it so that doesn't stop all the reports going out.
TODO: Fix it so channels that have no activity get some sort of stub
"Sorry, you should do more talking" report.