### PR TITLE
bugfix: Do not exclude fields from rows whose value is 0

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def prune_empty(row):
     """
     new_row = {}
     for k in row:
-        if row[k]:
+        if row[k] or row[k] == 0:
             new_row[k] = row[k]
     return new_row
 


### PR DESCRIPTION
evaluate to truth; but that also excluded fields whose value was 0,
which is useful for things like tz_offset.  Now, we only exclude fields
if they are *both* not True and not zero.