### PR TITLE
Need to join channels before setting their topic

### DIFF
--- a/user_and_channel_report
+++ b/user_and_channel_report
@@ -40,8 +40,8 @@ f.write(json.dumps(report, indent=4))
 f.close()
 for user in users:
     # slack_user_reporter.send_report(user, report, previous_report, send=True, override_uid=roy)
-    slack_user_reporter.send_report(user, report, previous_report, send=True)
-
+    # slack_user_reporter.send_report(user, report, previous_report, send=True)
+    pass
 topic = "Channel for automated postings of channel stats for the #{} channel.  Feedback/questions to #rands-slack-statistics"
 
 for channel in channels:
@@ -49,8 +49,7 @@ for channel in channels:
         dest = channel_dict[channel]
         name = cobj.get(channel)['name']
         nt = topic.format(name)
-        sobj.conditional_set_topic(dest, nt)
-        slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
+        sobj.conditional_set_topic(dest, nt, leave=True)
+        # slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
     except:
         print("Failed to send report to {}".format(channel))
-

--- a/user_and_channel_report
+++ b/user_and_channel_report
@@ -40,8 +40,8 @@ f.write(json.dumps(report, indent=4))
 f.close()
 for user in users:
     # slack_user_reporter.send_report(user, report, previous_report, send=True, override_uid=roy)
-    # slack_user_reporter.send_report(user, report, previous_report, send=True)
-    pass
+    slack_user_reporter.send_report(user, report, previous_report, send=True)
+
 topic = "Channel for automated postings of channel stats for the #{} channel.  Feedback/questions to #rands-slack-statistics"
 
 for channel in channels:
@@ -50,6 +50,6 @@ for channel in channels:
         name = cobj.get(channel)['name']
         nt = topic.format(name)
         sobj.conditional_set_topic(dest, nt, leave=True)
-        # slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
+        slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=dest, summary=True)
     except:
         print("Failed to send report to {}".format(channel))


### PR DESCRIPTION
we need to automatically join channels we'll set topics for.  So

1. Added join_channel() method to slacker.py
2. Added leave_channel() method to slacker.py
3. set_topic() now automatically calls join_channel()
4. added a `leave` optional parameteer to set_topic() and conditional_set_topic(); if set, we will automatically leave the channel after setting the topic.
5. Modified call of conditional_set_topic() in user_and_channel_report to specify `leave` == True