### PR TITLE
Fix several (potentially-unrelated) errors causing some channel reports to not run successfully

### DIFF
--- a/slack_channel_report.py
+++ b/slack_channel_report.py
@@ -102,7 +102,6 @@ class SlackChannelReport(object):
             blocks.append(self.sf.text_block(text))
             return blocks
         if cid not in pur['channel_stats']:
-            print("Oops -- no previous week data")
             text = "*Note:* No data exists for the previous (penultimate) week"
             blocks.append(self.sf.text_block(text))
         blocks.append(self.membercount(cid, ur['start_date'], ur['end_date']))

--- a/slack_channel_report.py
+++ b/slack_channel_report.py
@@ -101,6 +101,10 @@ class SlackChannelReport(object):
             text = "There was no activity in this channel for this time period"
             blocks.append(self.sf.text_block(text))
             return blocks
+        if cid not in pur['channel_stats']:
+            print("Oops -- no previous week data")
+            text = "*Note:* No data exists for the previous (penultimate) week"
+            blocks.append(self.sf.text_block(text))
         blocks.append(self.membercount(cid, ur['start_date'], ur['end_date']))
         blocks.append(self.messages(cid, ur, pur))
         blocks.append(self.sf.divider())
@@ -139,7 +143,14 @@ class SlackChannelReport(object):
         """
         Report on activity per hour of the workday
         """
-        d = ur['enriched_channel'][cid]['posting_hours']
+        # Why might we not have posting hours? One possibility is
+        # that posting hours are just for weekdays, so if the only Activity
+        # was during the weekend, we won't see posting hours stats
+        d = ur['enriched_channel'][cid].get("posting_hours")
+        if not d:
+            text = "*Note*: No weekday posting hours statistics are available, possibly because all activity during this time period was during the weekend"
+            block = self.sf.text_block(text)
+            return [block]
         return self.sf.posting_hours(d)
 
     def reacted_messages(self, ur, cid):

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,10 @@ class DecimalEncoder(json.JSONEncoder):
         return super(DecimalEncoder, self).default(o)
 
 
+def save_json(j, fname):
+    s = dumps(j)
+    save(s, fname)
+
 def dumps(j, indent=4):
     """
     json.dumps(j), but deal with Decimal encoding
@@ -110,4 +114,3 @@ def make_url(cid, ts):
     Return a URL for the message specified
     """
     return "https://{}.slack.com/archives/{}/p{}".format(config.slack_name, cid, ts.replace(".", ""))
-


### PR DESCRIPTION
Omnibus branch to deal with the failure of #negage-and-retain, #rands-slack-rules, and #diversity channel reports.  

Two bugs fixed by this are:

1. We would throw an exception previously if a channel had no activity during the time period;

2. We tried to show posting hours, but posting hours are only for weekday messages; so a channel with activity but where activity only occurred on the weekend would throw an error trying to look at posting hours; we now catch this situation and annotate the report with the fact this information is unavailable and the likely cause of it.  