### PR TITLE
change label for thread responses

### DIFF
--- a/slack_user_report.py
+++ b/slack_user_report.py
@@ -39,7 +39,7 @@ class SlackUserReport(object):
         header = "*Public User Activity Report for {}*"
         header = header.format(ur['user'])
         blocks.append(self.sf.text_block(header))
-        
+
         uc_entry = self.uc.get(uid)
         fp_entry = self.fp.get(uid)
         if uc_entry:
@@ -48,11 +48,11 @@ class SlackUserReport(object):
         if fp_entry:
             first_message = "Your first public message was posted on {}, {:,} days ago. {}".format(fp_entry['date'], fp_entry['days'], fp_entry['url'])
             blocks.append(self.sf.text_block(first_message))
-            
+
         blocks.append(self.sf.divider())
-            
+
         blocks.append(self.sf.text_block("*Last Week (between {} and {})*".format(ur['start_date'], ur['end_date'])))
-            
+
         m = "You posted *{}* words in *{}* public messages."
         m = m.format(self.sf.comparison(us, pus, ['count', 1]), self.sf.comparison(us, pus, ['count', 0]))
         m += "\n"
@@ -82,8 +82,8 @@ class SlackUserReport(object):
         blocks += self.topten(ur, pur, uid, 'reactions_from', "The people who most reacted to you are")
         blocks += self.topten(ur, pur, uid, 'reacted_to', "The people you most reacted to are")
         blocks += self.topten(ur, pur, uid, 'reactions_combined', "Reaction Affinity")
-        blocks += self.topten(ur, pur, uid, 'author_thread_responded', "Authors whose threads you responded to the most")
-        blocks += self.topten(ur, pur, uid, 'thread_responders', "Most frequent responders to your threads")
+        blocks += self.topten(ur, pur, uid, 'author_thread_responded', "In-thread responses per original author (top ten authors)")
+        blocks += self.topten(ur, pur, uid, 'thread_responders', "In-thread responses to your threads (top ten authors)")
         blocks += self.topten(ur, pur, uid, 'threads_combined', "Thread Affinity")
         blocks += self.topten(ur, pur, uid, 'you_mentioned', "The people you mentioned the most")
         blocks += self.topten(ur, pur, uid, 'mentioned_you', "The people who mentioned you the most")
@@ -104,7 +104,7 @@ class SlackUserReport(object):
     def unsubscribe(self):
         unsub_block = self.sf.text_block('You are receiving this because you are a member of #zmeta-per-user-report-optin. Feedback is welcome over in #rands-slack-statistics.')
         return [unsub_block]
-    
+
     def firstpost(self, uid):
         blocks = []
         entry = self.fp.get(uid)


### PR DESCRIPTION
From conversation in RLS on 5/5/2020:



alexis:flag-za:  06:17
On the “Authors whose threads you responded to the most” section, I think it is counting ‘total number of responses to threads started by this author’, and 2 responses in one thread will be counted as +2 on the number.  Is this correct?
If it is correct, I think either the title or the way we count should be different.  For me, this section is a measure of how many different people I interact with on different topics - and multiple responses of mine to one thread should (in my mind) be counted as 1.

royrapoport  06:25
How would you rephrase the header, @alexis?

alexis:flag-za:  06:38
“In-thread responses per original author” or “Number of times you responded to a thread started by author” (assuming my initial assumption holds). (edited) 
