### PR TITLE
report sending fixes

### DIFF
--- a/slack_channel_report.py
+++ b/slack_channel_report.py
@@ -45,7 +45,7 @@ class SlackChannelReport(object):
 
     def messages(self, cid, ur, pur):
         text = ""
-        m = "*{}* messages and *{}* words were posted to the channel"
+        m = "{} messages and {} words were posted to the channel"
         m = m.format(self.sf.comparison(ur, pur, ['channels', cid, 0]), self.sf.comparison(ur, pur, ['channels', cid, 1]))
         text += m
         cur_user_count = len(ur['channel_user'].get(cid, []))
@@ -57,7 +57,7 @@ class SlackChannelReport(object):
         prevtotal = pur['statistics']["words"]
         curper = float("{:.1f}".format(curchannelvol * 100.0 / curtotal))
         prevper = float("{:.1f}".format(prevchannelvol * 100.0 / prevtotal))
-        m = "In all, this channel represented *{}* of total traffic"
+        m = "In all, this channel represented {} of total traffic"
         m = m.format(self.sf.simple_comparison(curper, prevper, True, True, True))
         text += "\n" + m
         b = self.sf.text_block(text)
@@ -75,8 +75,8 @@ class SlackChannelReport(object):
         ctr = 1
         for user in cur_user_names:
             fields.append("{} {}".format(ctr, self.sf.show_uid(user)))
-            m = "*{}* m".format(self.sf.comparison(ur, pur, ['channel_user', cid, user, 0]))
-            m += " *{}* w".format(self.sf.comparison(ur, pur, ['channel_user', cid, user, 1]))
+            m = "{} m".format(self.sf.comparison(ur, pur, ['channel_user', cid, user, 0]))
+            m += " {} w".format(self.sf.comparison(ur, pur, ['channel_user', cid, user, 1]))
             fields.append(m)
             ctr += 1
         for fset in self.sf.make_fields(fields):
@@ -215,7 +215,7 @@ class SlackChannelReport(object):
             if self.fake:
                 cname = self.sf.get_fake_channel(channel_name)
             f1 = "{} *{}*".format(ctr, cname)
-            f2 = "*{}* rank, *{}* m, *{}* w"
+            f2 = "*{}* rank, {} m, {} w"
             messages = self.sf.comparison(ur, pur, ['enriched_channels', channel_name, 'messages'])
             words = self.sf.comparison(ur, pur, ['enriched_channels', channel_name, 'words'])
             f2 = f2.format(channel['rank'], messages, words)

--- a/slack_channel_report.py
+++ b/slack_channel_report.py
@@ -84,8 +84,6 @@ class SlackChannelReport(object):
             blocks.append(block)
         return blocks
 
-
-
     def make_header(self, ur, pur, cid):
         blocks = []
         header = "Channel Activity Report for *{}* Between {} and {}"
@@ -117,18 +115,6 @@ class SlackChannelReport(object):
         blocks += self.replied_messages(ur, cid)
         blocks += self.posting_hours(ur, cid)
         blocks += self.posting_days(ur, cid)
-        #blocks += self.make_channels(ur, pur)
-        #blocks.append(self.sf.divider())
-        #blocks += self.popular_reactions(ur, uid)
-        #blocks += self.topten(ur, pur, uid, 'reactions_from', "The people who most responded to you are")
-        #blocks += self.topten(ur, pur, uid, 'reacted_to', "The people you most responded to are")
-        #blocks += self.topten(ur, pur, uid, 'reactions_combined', "Reaction Affinity")
-        #blocks += self.topten(ur, pur, uid, 'author_thread_responded', "Authors whose threads you responded to the most")
-        #blocks += self.topten(ur, pur, uid, 'thread_responders', "Most frequent responders to your threads")
-        #blocks += self.topten(ur, pur, uid, 'threads_combined', "Thread Affinity")
-        #blocks += self.topten(ur, pur, uid, 'you_mentioned', "The people you mentioned the most")
-        #blocks += self.topten(ur, pur, uid, 'mentioned_you', "The people who mentioned you the most")
-        #blocks += self.topten(ur, pur, uid, 'mentions_combined', "Mention Affinity")
         return blocks
 
     def posting_days(self, ur, cid):

--- a/slack_user_report.py
+++ b/slack_user_report.py
@@ -53,7 +53,7 @@ class SlackUserReport(object):
 
         blocks.append(self.sf.text_block("*Last Week (between {} and {})*".format(ur['start_date'], ur['end_date'])))
 
-        m = "You posted *{}* words in *{}* public messages."
+        m = "You posted {} words in {} public messages."
         m = m.format(self.sf.comparison(us, pus, ['count', 1]), self.sf.comparison(us, pus, ['count', 0]))
         m += "\n"
         m += "That made you the *{}*-ranked poster on the Slack and meant you contributed "
@@ -150,7 +150,7 @@ class SlackUserReport(object):
             return []
 
         pd = pur['enriched_user'][uid].get(label, {})
-        t = "*{}* times between you and *{}* unique people"
+        t = "{} times between you and {} unique people"
         total = sum(d.values())
         count = len(list(d.keys()))
         ptotal = sum(pd.values())
@@ -202,7 +202,7 @@ class SlackUserReport(object):
             cname = channel['name']
             cid = channel['slack_cid']
             f1 = "{} *{}*".format(ctr, self.sf.show_cid(cid))
-            f2 = "*{}* rank, *{}* m, *{}* w"
+            f2 = "*{}* rank, {} m, {} w"
             messages = self.sf.comparison(ur, pur, ['enriched_channels', channel_name, 'messages'])
             words = self.sf.comparison(ur, pur, ['enriched_channels', channel_name, 'words'])
             f2 = f2.format(channel['rank'], messages, words)

--- a/user_and_channel_report
+++ b/user_and_channel_report
@@ -16,17 +16,18 @@ import report_generator
 import report_targets
 
 parser = argparse.ArgumentParser(description="Send user and channel reports")
-parser.add_argument("--destination", help="Specify @username or #channel to send all reports to")
+parser.add_argument("--override", help="Specify @username or #channel to send all reports to")
 parser.add_argument("--regen", action="store_true", help="Force regeneration of reports")
 parser.add_argument("--nochannel", action="store_true", help="Do not send channel activity reports")
 parser.add_argument("--nouser", action="store_true", help="Do not send user activity reports")
 parser.add_argument("--user", help="Send user report for just this @user")
 parser.add_argument("--channel", help="Send channel report for just this #channel")
+parser.add_argument("--nosend", action="store_true", help="Do all processing but don't actually send out any reports")
 
 args = parser.parse_args()
-destination = None
-if args.destination:
-    destination = report_utils.override(args.destination)
+override = None
+if args.override:
+    override = report_utils.override(args.override)
 
 rg = report_generator.ReportGenerator()
 slack_user_reporter = slack_user_report.SlackUserReport()
@@ -62,12 +63,14 @@ f.write(json.dumps(report, indent=4))
 f.close()
 if not args.nouser:
     for user in users:
-        user_destination = destination or user
-        try:
-            slack_user_reporter.send_report(user, report, previous_report, send=True, override_uid=user_destination)
-        except Exception as ex:
-            print("Failed to send a report to {}: {} {}".format(user, ex, sys.exc_info()[0]))
-            traceback.print_exc()
+        user_destination = override or user
+        if not args.nosend:
+            print("Sendnig user reports")
+            try:
+                slack_user_reporter.send_report(user, report, previous_report, send=True, override_uid=user_destination)
+            except Exception as ex:
+                print("Failed to send a report to {}: {} {}".format(user, ex, sys.exc_info()[0]))
+                traceback.print_exc()
 
 topic = "Channel for automated postings of channel stats for the #{} channel.  Feedback/questions to #rands-slack-statistics"
 
@@ -76,14 +79,17 @@ if not args.nochannel:
         dest = channel_dict[channel]
         name = cobj.get(channel)['name']
         nt = topic.format(name)
-        channel_destination = dest or channel
+        channel_destination = override or dest
+        print("For channel {}, will send to {}".format(name, channel_destination))
         try:
             sobj.conditional_set_topic(dest, nt, leave=True)
         except Exception as ex:
             print("Failed to set topic on {}/{}: {} {}".format(channel, name, ex, sys.exc_info()[0]))
             traceback.print_exc()
-        try:
-            slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=channel_destination, summary=True)
-        except Exception as ex:
-            print("Failed to send report to {}/{}: {} {}".format(channel, name, ex, sys.exc_info()[0]))
-            traceback.print_exc()
+        if not args.nosend:
+            print("Sending channel report for {}".format(name))
+            try:
+                slack_channel_reporter.send_report(channel, report, previous_report, send=True, override_uid=channel_destination, summary=True)
+            except Exception as ex:
+                print("Failed to send report to {}/{}: {} {}".format(channel, name, ex, sys.exc_info()[0]))
+                traceback.print_exc()


### PR DESCRIPTION
1. Add --nosend to noot actually send oout reports;
2. Add priint for each channel report indicating where it will be sent
3. Fix minor bug in @jenna's fix to my very big bug that made it
impossible to override channel destinations
4. Change --destination to --override to make it clearer